### PR TITLE
Update to Swift 5.9 and enable StrictConcurrency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.7
+// swift-tools-version: 5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -47,4 +47,13 @@ let package = Package(
       resources: [
         .process("Resources"),
       ]),
+  ],
+  swiftLanguageVersions: [.v5]
+)
+
+for target in package.targets {
+  target.swiftSettings = target.swiftSettings ?? []
+  target.swiftSettings?.append(contentsOf: [
+    .enableExperimentalFeature("StrictConcurrency")
   ])
+}

--- a/Sources/ApolloExtensions/ApolloClientProtocol+Defaults.swift
+++ b/Sources/ApolloExtensions/ApolloClientProtocol+Defaults.swift
@@ -1,7 +1,7 @@
 // Created by Brad Bergeron on 10/17/23.
 
-import Apollo
-import ApolloAPI
+@preconcurrency import Apollo
+@preconcurrency import ApolloAPI
 import Foundation
 
 extension ApolloClientProtocol {

--- a/Sources/ApolloExtensions/Mocks/MockApolloClient.swift
+++ b/Sources/ApolloExtensions/Mocks/MockApolloClient.swift
@@ -2,8 +2,8 @@
 
 #if DEBUG
 
-import Apollo
-import ApolloAPI
+@preconcurrency import Apollo
+@preconcurrency import ApolloAPI
 import Foundation
 
 // MARK: - MockApolloClient

--- a/Sources/ApolloExtensionsTestSchema/SchemaMetadata.graphql.swift
+++ b/Sources/ApolloExtensionsTestSchema/SchemaMetadata.graphql.swift
@@ -16,7 +16,7 @@ public protocol MutableInlineFragment: ApolloAPI.MutableSelectionSet & ApolloAPI
 where Schema == ApolloExtensionsTestSchema.SchemaMetadata {}
 
 public enum SchemaMetadata: ApolloAPI.SchemaMetadata {
-  public static let configuration: any ApolloAPI.SchemaConfiguration.Type = SchemaConfiguration.self
+  public static var configuration: any ApolloAPI.SchemaConfiguration.Type { SchemaConfiguration.self }
 
   public static func objectType(forTypename typename: String) -> ApolloAPI.Object? {
     switch typename {

--- a/Tests/ApolloExtensionsTests/ApolloClientProtocolDefaultsTests.swift
+++ b/Tests/ApolloExtensionsTests/ApolloClientProtocolDefaultsTests.swift
@@ -12,7 +12,7 @@ final class ApolloClientProtocolDefaultsTests: XCTestCase {
 
   // MARK: Internal
 
-  override func setUp() async throws{
+  override func setUp() async throws {
     apolloClient = MockApolloClient()
   }
 

--- a/Tests/ApolloExtensionsTests/ApolloClientProtocolDefaultsTests.swift
+++ b/Tests/ApolloExtensionsTests/ApolloClientProtocolDefaultsTests.swift
@@ -1,17 +1,18 @@
 // Created by Brad Bergeron on 10/19/23.
 
-import Apollo
+@preconcurrency import Apollo
 import XCTest
 
 @testable import ApolloExtensions
 
 // MARK: - ApolloClientProtocolDefaultsTests
 
+@MainActor
 final class ApolloClientProtocolDefaultsTests: XCTestCase {
 
   // MARK: Internal
 
-  override func setUp() {
+  override func setUp() async throws{
     apolloClient = MockApolloClient()
   }
 


### PR DESCRIPTION
### TL;DR

Upgraded Swift tools version to 5.9 and enabled strict concurrency checking across the codebase.

### What changed?

- Updated Swift tools version from 5.7 to 5.9
- Added `StrictConcurrency` experimental feature to all targets
- Added `@preconcurrency` attribute to Apollo and ApolloAPI imports
- Fixed a computed property in SchemaMetadata to use getter syntax
- Added `@MainActor` annotation to test class
- Updated test setup method to be async

### How to test?

1. Build the package with Swift 5.9
2. Run all tests to ensure they pass with the new concurrency settings
3. Verify that the package works correctly in projects that use Swift concurrency

### Why make this change?

This change improves the codebase's concurrency safety by enabling strict concurrency checking. The `@preconcurrency` attributes help manage the transition to concurrency-safe code by marking imported modules that may not be fully concurrency-safe yet. This prepares the codebase for better compatibility with Swift's concurrency model and helps prevent data races.