### PR TITLE
Update CI workflow to use macOS 15

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -18,24 +18,38 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  PACKAGE_NAME: ApolloExtensions
+
 jobs:
   build:
     name: Build and Test
-    runs-on: macos-14
-    env:
-      PACKAGE_NAME: ApolloExtensions
+    runs-on: macos-15
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
+
       - name: Build
         run: swift build
+
       - name: Test
+        id: test
         run: swift test --enable-code-coverage
+
       - name: Prepare Code Coverage
-        run: xcrun llvm-cov export --ignore-filename-regex='(Tests|Mocks)[/\\].*' -format="lcov" .build/debug/${{ env.PACKAGE_NAME }}PackageTests.xctest/Contents/MacOS/${{ env.PACKAGE_NAME }}PackageTests -instr-profile .build/debug/codecov/default.profdata > info.lcov
+        id: prepare-codecov-coverage-report
+        if: steps.test.outcome == 'success'
+        run: |
+          set -o pipefail && \
+          xcrun llvm-cov export \
+          -format="lcov" \
+          --ignore-filename-regex='(Tests)[/\\].*' \
+          -instr-profile .build/debug/codecov/default.profdata \
+          .build/debug/${{ env.PACKAGE_NAME }}PackageTests.xctest/Contents/MacOS/${{ env.PACKAGE_NAME }}PackageTests \
+          > info.lcov
+
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        if: steps.prepare-codecov-coverage-report.outcome == 'success'
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          verbose: true
-          fail_ci_if_error: true


### PR DESCRIPTION
us### TL;DR

Updated GitHub Actions workflow to use the latest macOS runner and improved code coverage reporting.

### What changed?

- Upgraded macOS runner from `macos-14` to `macos-15`
- Updated GitHub Actions dependencies:
  - `actions/checkout` from v4 to v5
  - `codecov/codecov-action` from v4 to v5
- Improved code coverage reporting:
  - Added step IDs for better workflow control
  - Added conditional execution for code coverage steps
  - Refined the code coverage command with better formatting and error handling
  - Removed verbose flag and fail_ci_if_error option from Codecov action
- Moved `PACKAGE_NAME` environment variable to the workflow level

### How to test?

1. Verify the workflow runs successfully on a PR
2. Confirm code coverage reports are still being generated and uploaded to Codecov
3. Check that the workflow properly handles test failures without attempting to generate coverage reports

### Why make this change?

This update ensures we're using the latest available tools and infrastructure for our CI pipeline. The improved code coverage reporting with conditional steps makes the workflow more robust by preventing coverage generation attempts when tests fail. The pipeline will now be more efficient and provide clearer feedback on failures.